### PR TITLE
Fix cache expiration check

### DIFF
--- a/spec/webdrivers/cache_spec.cr
+++ b/spec/webdrivers/cache_spec.cr
@@ -1,0 +1,57 @@
+require "../spec_helper"
+
+describe Webdrivers::Cache do
+  describe ".fetch" do
+    it "returns cached file content if found" do
+      with_tempfile do |path|
+        result = Webdrivers::Cache.fetch(path, 10.hours) { "goodbye!" }
+
+        result.should eq "hello!"
+      end
+    end
+
+    it "returns block result if cache file not found" do
+      with_missing_file do |path|
+        result = Webdrivers::Cache.fetch(path, 10.hours) { "goodbye!" }
+
+        result.should eq "goodbye!"
+      end
+    end
+
+    it "writes block result to cache file path if cache file not found" do
+      with_missing_file do |path|
+        Webdrivers::Cache.fetch(path, 10.hours) { "goodbye!" }
+
+        File.exists?(path).should be_true
+      end
+    end
+
+    it "overwrites existing cache file path with block result if modification time too old" do
+      with_tempfile do |path|
+        File.utime(1.day.ago, 1.day.ago, path)
+        result = Webdrivers::Cache.fetch(path, 10.hours) { "goodbye!" }
+
+        result.should eq "goodbye!"
+        File.read(path).should eq "goodbye!"
+      end
+    end
+  end
+end
+
+private def with_tempfile
+  tempfile = File.tempfile(suffix: ".txt") do |file|
+    file.print("hello!")
+  end
+  yield tempfile.path
+ensure
+  tempfile.try(&.delete)
+end
+
+private def with_missing_file
+  tempname = File.tempname(suffix: ".txt")
+  yield tempname
+ensure
+  tempname.try do |temp_path|
+    FileUtils.rm(temp_path) if File.exists?(temp_path)
+  end
+end

--- a/src/webdrivers/cache.cr
+++ b/src/webdrivers/cache.cr
@@ -1,4 +1,4 @@
-module Cache
+module Webdrivers::Cache
   def self.fetch(cache_path : String, expires_in : Time::Span, &block)
     value = read(cache_path, expires_in)
     return value if value
@@ -18,7 +18,7 @@ module Cache
   private def self.read(cache_path, expires_in) : String?
     return unless File.exists?(cache_path)
 
-    actual_duration = File.info(cache_path).modification_time - Time.utc
+    actual_duration = Time.utc - File.info(cache_path).modification_time
     return if actual_duration >= expires_in
 
     File.read(cache_path)


### PR DESCRIPTION
Fixes #4

A bug in the cache check meant that it was never checking for a new driver. Now it should _actually_ check for new drivers when the `cache_duration` has passed which is [currently set](https://github.com/matthewmcgarvey/webdrivers.cr/blob/2e02ba064eb4405745a4d6049484a64270d25f13/src/webdrivers.cr#L17) at 24 hours.

There was also a bug/mistake in that the `Cache` was not namespaced correctly.