### PR TITLE
Follow crystal 1.0.0 in shard.yml

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -4,7 +4,7 @@ description: |
   Helps manage drivers for Selenium, such as the Chromedriver.
 authors:
   - Matthew McGarvey <matthewmcgarvey14@gmail.com>
-crystal: ">= 0.35.0, 2.0.0"
+crystal: ">= 0.35.0, < 2.0.0"
 license: MIT
 
 dependencies:


### PR DESCRIPTION
When I created sandbox to ensure shards behavior

Before
---

```yaml
name: foobar
version: 0.1.1

authors:
  - kachick

crystal: ">= 0.35.0, < 2.0.0"

license: MIT

dependencies:
  webdrivers:
    github: matthewmcgarvey/webdrivers.cr
    version: ~> 0.3.2
```

```console
$ crystal --version
Crystal 1.0.0 (2021-03-22)

LLVM: 9.0.1
Default target: x86_64-apple-macosx

$ shards --version
Shards 0.14.1 (2021-03-10)

$ shards
Resolving dependencies
Fetching https://github.com/matthewmcgarvey/webdrivers.cr.git
Fetching https://github.com/luckyframework/habitat.git
Fetching https://github.com/naqvis/crystar.git
Unable to satisfy the following requirements:

- `crystal (~> 0.35, >= 0.35.0)` required by `webdrivers 0.3.2`
- `crystal (~> 0.36, >= 0.36.1)` required by `habitat 0.4.6`
- `crystal (~> 0.36, >= 0.36.0)` required by `crystar 0.1.9`
Failed to resolve dependencies, try updating incompatible shards or use --ignore-crystal-version as a workaround if no update is available.
```

After
---

```yaml
name: foobar
version: 0.1.1

authors:
  - kachick

crystal: ">= 0.35.0, < 2.0.0"

license: MIT

dependencies:
  webdrivers:
    github: kachick/webdrivers.cr
    branch: follow-crystal-1.0.0
    version: ~> 0.3.2
```

```console
$ shards
Resolving dependencies
Fetching https://github.com/kachick/webdrivers.cr.git
Fetching https://github.com/luckyframework/habitat.git
Fetching https://github.com/naqvis/crystar.git
Unable to satisfy the following requirements:

- `crystal (>= 0.35.0, < 2.0.0)` required by `webdrivers 0.3.2+git.commit.cbc0d4020452cfcdcd02cb790e9349863de0dfe7`
- `crystal (~> 0.35, >= 0.35.0)` required by `habitat 0.4.4`
Failed to resolve dependencies, try updating incompatible shards or use --ignore-crystal-version as a workaround if no update is available.
```

I guess the specifying version might need this change 😅 (If not, sorry for annoying with this PR! 🙇 )

https://github.com/crystal-lang/shards/blob/addc26a3f22fee9fccb01cbb3e8878bef02d4295/docs/shard.yml.adoc