### PR TITLE
Updating the chromedriver install location

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -12,9 +12,9 @@ dependencies:
     github: luckyframework/habitat
     version: ~> 0.4.7
   crystar:
-    git: https://github.com/naqvis/crystar.git
-    commit: 56db8bb9dfbd5ed6d7908353405a5fae632a6561
+    github: naqvis/crystar
+    version: ~> 0.3.1
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 1.1.0
+    version: ~> 1.5

--- a/spec/webdrivers/cache_spec.cr
+++ b/spec/webdrivers/cache_spec.cr
@@ -38,7 +38,7 @@ describe Webdrivers::Cache do
   end
 end
 
-private def with_tempfile
+private def with_tempfile(&)
   tempfile = File.tempfile(suffix: ".txt") do |file|
     file.print("hello!")
   end
@@ -47,7 +47,7 @@ ensure
   tempfile.try(&.delete)
 end
 
-private def with_missing_file
+private def with_missing_file(&)
   tempname = File.tempname(suffix: ".txt")
   yield tempname
 ensure

--- a/spec/webdrivers/chrome/driver_remote_version_finder_spec.cr
+++ b/spec/webdrivers/chrome/driver_remote_version_finder_spec.cr
@@ -7,7 +7,8 @@ module Webdrivers::Chrome
       File.delete(finder.cache_path) if File.exists?(finder.cache_path)
     end
 
-    it "will limit return version to matching major version if version" do
+    # TODO: Figure out if this is necessary
+    pending "will limit return version to matching major version if version" do
       version = SemanticVersion.new(
         major: 71,
         minor: 22,

--- a/spec/webdrivers/chrome/driver_remote_version_finder_spec.cr
+++ b/spec/webdrivers/chrome/driver_remote_version_finder_spec.cr
@@ -7,8 +7,7 @@ module Webdrivers::Chrome
       File.delete(finder.cache_path) if File.exists?(finder.cache_path)
     end
 
-    # TODO: Figure out if this is necessary
-    pending "will limit return version to matching major version if version" do
+    it "will limit return version to matching major version when version is provided" do
       version = SemanticVersion.new(
         major: 71,
         minor: 22,

--- a/src/webdrivers/cache.cr
+++ b/src/webdrivers/cache.cr
@@ -1,5 +1,5 @@
 module Webdrivers::Cache
-  def self.fetch(cache_path : String, expires_in : Time::Span, &block)
+  def self.fetch(cache_path : String, expires_in : Time::Span, &)
     value = read(cache_path, expires_in)
     return value if value
 

--- a/src/webdrivers/chrome/driver_remote_version_finder.cr
+++ b/src/webdrivers/chrome/driver_remote_version_finder.cr
@@ -2,6 +2,11 @@ class Webdrivers::Chrome::DriverRemoteVersionFinder
   getter cache_path : String
   getter version : SemanticVersion?
 
+  # Since Chrome v115+ the download locations have changed.
+  # We can use https://github.com/GoogleChromeLabs/chrome-for-testing#json-api-endpoints
+  # to find specific API endpoints
+  MANIFEST_API_ENDPOINT = "https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json"
+
   def initialize(driver_directory, @version = nil)
     @cache_path = File.join(driver_directory, "chromedriver.version")
   end
@@ -12,15 +17,9 @@ class Webdrivers::Chrome::DriverRemoteVersionFinder
 
   private def find_raw_version
     Cache.fetch(cache_path, Webdrivers.settings.cache_duration) do
-      response = HTTP::Client.get("https://chromedriver.storage.googleapis.com/#{latest_release}")
-      response.body
+      response = HTTP::Client.get(MANIFEST_API_ENDPOINT)
+      google = JSON.parse(response.body)
+      google.dig("channels", "Stable", "version").as_s
     end
-  end
-
-  private def latest_release
-    limitting_version = version
-    return "LATEST_RELEASE" if limitting_version.nil?
-
-    "LATEST_RELEASE_#{limitting_version.major}"
   end
 end

--- a/src/webdrivers/chrome/install_driver_executor.cr
+++ b/src/webdrivers/chrome/install_driver_executor.cr
@@ -3,8 +3,10 @@ class Webdrivers::Chrome::InstallDriverExecutor
   getter current_version : SemanticVersion?
   getter driver_directory : String
   getter driver_name : String
+  getter cache_path : String
 
   def initialize(@install_version, @driver_directory, @driver_name, @current_version)
+    @cache_path = File.join(Common.driver_directory, "chromedriver.download_url")
   end
 
   def execute
@@ -12,9 +14,15 @@ class Webdrivers::Chrome::InstallDriverExecutor
 
     Dir.mkdir_p(driver_directory) unless File.exists?(driver_directory)
 
+    if install_version.major < 115
+      normalized_driver_name = driver_name
+    else
+      normalized_driver_name = File.join("chromedriver-#{download_url_platform}", driver_name)
+    end
+
     FileUtils.cd(driver_directory) do
       zip = download_file(from: download_url, to: download_url_filename)
-      Common::ZipExtractor.new(zip, File.join("chromedriver-#{download_url_platform}", driver_name), driver_directory).extract
+      Common::ZipExtractor.new(zip, normalized_driver_name, driver_directory).extract
       zip.delete
       File.chmod(driver_name, Common::EXECUTABLE_PERMISSIONS)
     end
@@ -29,15 +37,31 @@ class Webdrivers::Chrome::InstallDriverExecutor
   end
 
   private def download_url : String
-    response = HTTP::Client.get(Webdrivers::Chrome::DriverRemoteVersionFinder::MANIFEST_API_ENDPOINT)
-    google = JSON.parse(response.body.to_s)
-    downloads = google.dig("channels", "Stable", "downloads", "chromedriver").as_a
-    platform = downloads.find! { |version| version["platform"].as_s == download_url_platform }
-    platform["url"].as_s
+    if install_version.major < 115
+      "https://chromedriver.storage.googleapis.com/#{converted_version}/#{download_url_filename}"
+    else
+      fetch_download_url_for_version
+    end
+  end
+
+  private def fetch_download_url_for_version : String
+    Cache.fetch(cache_path, Webdrivers.settings.cache_duration) do
+      response = HTTP::Client.get("#{chrome_for_testing_base_url}/known-good-versions-with-downloads.json")
+      google = JSON.parse(response.body.to_s)
+      downloads = google["versions"].as_a
+      version_found = downloads.find! { |version| version["version"].as_s == converted_version }
+      platforms = version_found.dig("downloads", "chromedriver").as_a
+      platform_found = platforms.find! { |platform| platform["platform"].as_s == download_url_platform }
+      platform_found["url"].as_s
+    end
   end
 
   private def converted_version : String
     SemverConverter.convert(install_version)
+  end
+
+  private def chrome_for_testing_base_url : String
+    "https://googlechromelabs.github.io/chrome-for-testing"
   end
 
   # TODO: Support Win64, and Mac Intel

--- a/src/webdrivers/chrome/install_driver_executor.cr
+++ b/src/webdrivers/chrome/install_driver_executor.cr
@@ -70,7 +70,7 @@ class Webdrivers::Chrome::InstallDriverExecutor
     when Common::OS::Linux
       "linux64"
     when Common::OS::Mac
-      "mac-arm64"
+      "mac-x64"
     when Common::OS::Windows
       "win32"
     else

--- a/src/webdrivers/chromedriver.cr
+++ b/src/webdrivers/chromedriver.cr
@@ -23,7 +23,7 @@ class Webdrivers::Chromedriver
 
   def self.install : String
     Chrome::InstallDriverExecutor.new(
-      install_version: latest_driver_version.not_nil!,
+      install_version: latest_driver_version.as(SemanticVersion),
       current_version: driver_version,
       driver_directory: Common.driver_directory,
       driver_name: driver_name

--- a/src/webdrivers/common/tar_gz_extractor.cr
+++ b/src/webdrivers/common/tar_gz_extractor.cr
@@ -9,7 +9,7 @@ class Webdrivers::Common::TarGzExtractor
   def extract
     Compress::Gzip::Reader.open(file) do |gzip|
       Crystar::Reader.open(gzip) do |tar|
-        entry = tar.next_entry.not_nil!
+        entry = tar.next_entry.as(Crystar::Header)
         destination_path = File.join(install_path, entry.name)
         File.delete(destination_path) if File.exists?(destination_path)
         File.write(destination_path, entry.io)

--- a/src/webdrivers/common/zip_extractor.cr
+++ b/src/webdrivers/common/zip_extractor.cr
@@ -9,7 +9,8 @@ class Webdrivers::Common::ZipExtractor
   def extract
     Compress::Zip::File.open(zip_file) do |zip_contents|
       driver = zip_contents[driver_name]
-      destination_path = File.join(install_path, driver.filename)
+      filepath = driver.filename.split(File::SEPARATOR).last
+      destination_path = File.join(install_path, filepath)
       File.delete(destination_path) if File.exists?(destination_path)
       driver.open { |io| File.write(destination_path, io) }
     end

--- a/src/webdrivers/geckodriver.cr
+++ b/src/webdrivers/geckodriver.cr
@@ -17,7 +17,7 @@ class Webdrivers::Geckodriver
 
   def self.install : String
     Gecko::InstallDriverExecutor.new(
-      install_version: latest_driver_version.not_nil!,
+      install_version: latest_driver_version.as(SemanticVersion),
       current_version: driver_version,
       driver_directory: Common.driver_directory,
       driver_name: driver_name


### PR DESCRIPTION
Fixes #13

Starting with chrome v115, they changed where the files are downloaded. They also changed the structure of the zip files. 

This PR still allows you to pull up the old chromedriver versions, but also takes in to account later versions. If you have a specific version of the Chrome browser installed, it will attempt to find the matching chromedriver, otherwise it just grabs the latest Stable version.