### PR TITLE
Allow configuring the cache file path

### DIFF
--- a/spec/webdrivers/chrome/driver_remote_version_finder_spec.cr
+++ b/spec/webdrivers/chrome/driver_remote_version_finder_spec.cr
@@ -4,7 +4,6 @@ module Webdrivers::Chrome
   describe DriverRemoteVersionFinder do
     Spec.after_each do
       finder = DriverRemoteVersionFinder.new(Common.driver_directory, cache_file: "chromedriver.version.test")
-      # Clear cache again after runs
       Webdrivers::Cache.delete(finder.cache_path)
     end
 

--- a/spec/webdrivers/chrome/driver_remote_version_finder_spec.cr
+++ b/spec/webdrivers/chrome/driver_remote_version_finder_spec.cr
@@ -2,9 +2,10 @@ require "../../spec_helper"
 
 module Webdrivers::Chrome
   describe DriverRemoteVersionFinder do
-    before_each do
-      finder = DriverRemoteVersionFinder.new(Common.driver_directory)
-      File.delete(finder.cache_path) if File.exists?(finder.cache_path)
+    Spec.after_each do
+      finder = DriverRemoteVersionFinder.new(Common.driver_directory, cache_file: "chromedriver.version.test")
+      # Clear cache again after runs
+      Webdrivers::Cache.delete(finder.cache_path)
     end
 
     it "will limit return version to matching major version when version is provided" do
@@ -13,7 +14,7 @@ module Webdrivers::Chrome
         minor: 22,
         patch: 1111
       )
-      finder = DriverRemoteVersionFinder.new(Common.driver_directory, version)
+      finder = DriverRemoteVersionFinder.new(Common.driver_directory, version, "chromedriver.version.test")
 
       result = finder.find
 

--- a/spec/webdrivers/chrome/driver_remote_version_finder_spec.cr
+++ b/spec/webdrivers/chrome/driver_remote_version_finder_spec.cr
@@ -2,7 +2,9 @@ require "../../spec_helper"
 
 module Webdrivers::Chrome
   describe DriverRemoteVersionFinder do
-    Spec.after_each do
+    Spec.around_each do |example|
+      example.run
+    ensure
       finder = DriverRemoteVersionFinder.new(Common.driver_directory, cache_file: "chromedriver.version.test")
       Webdrivers::Cache.delete(finder.cache_path)
     end

--- a/src/webdrivers/cache.cr
+++ b/src/webdrivers/cache.cr
@@ -9,6 +9,12 @@ module Webdrivers::Cache
     value
   end
 
+  def self.delete(cache_path) : Nil
+    if File.exists?(cache_path)
+      File.delete(cache_path)
+    end
+  end
+
   private def self.write(value, expires_in, cache_path)
     ensure_cache_path(File.dirname(cache_path))
 

--- a/src/webdrivers/chrome/driver_remote_version_finder.cr
+++ b/src/webdrivers/chrome/driver_remote_version_finder.cr
@@ -2,8 +2,8 @@ class Webdrivers::Chrome::DriverRemoteVersionFinder
   getter cache_path : String
   getter version : SemanticVersion?
 
-  def initialize(driver_directory, @version = nil)
-    @cache_path = File.join(driver_directory, "chromedriver.version")
+  def initialize(driver_directory, @version = nil, cache_file = "chromedriver.version")
+    @cache_path = File.join(driver_directory, cache_file)
   end
 
   def find : SemanticVersion?

--- a/src/webdrivers/chrome/install_driver_executor.cr
+++ b/src/webdrivers/chrome/install_driver_executor.cr
@@ -17,7 +17,7 @@ class Webdrivers::Chrome::InstallDriverExecutor
     if install_version.major < 115
       normalized_driver_name = driver_name
     else
-      normalized_driver_name = File.join("chromedriver-#{download_url_platform}", driver_name)
+      normalized_driver_name = "chromedriver-#{download_url_platform}/#{driver_name}"
     end
 
     FileUtils.cd(driver_directory) do

--- a/src/webdrivers/common/zip_extractor.cr
+++ b/src/webdrivers/common/zip_extractor.cr
@@ -8,7 +8,12 @@ class Webdrivers::Common::ZipExtractor
 
   def extract
     Compress::Zip::File.open(zip_file) do |zip_contents|
-      driver = zip_contents[driver_name]
+      begin
+        driver = zip_contents[driver_name]
+      rescue
+        pp! zip_contents.entries
+        raise "Entry #{driver_name} not found in zip"
+      end
       filepath = driver.filename.split(File::SEPARATOR).last
       destination_path = File.join(install_path, filepath)
       File.delete(destination_path) if File.exists?(destination_path)

--- a/src/webdrivers/common/zip_extractor.cr
+++ b/src/webdrivers/common/zip_extractor.cr
@@ -8,12 +8,7 @@ class Webdrivers::Common::ZipExtractor
 
   def extract
     Compress::Zip::File.open(zip_file) do |zip_contents|
-      begin
-        driver = zip_contents[driver_name]
-      rescue
-        pp! zip_contents.entries
-        raise "Entry #{driver_name} not found in zip"
-      end
+      driver = zip_contents[driver_name]
       filepath = driver.filename.split(File::SEPARATOR).last
       destination_path = File.join(install_path, filepath)
       File.delete(destination_path) if File.exists?(destination_path)

--- a/src/webdrivers/gecko/driver_remote_version_finder.cr
+++ b/src/webdrivers/gecko/driver_remote_version_finder.cr
@@ -1,8 +1,8 @@
 class Webdrivers::Gecko::DriverRemoteVersionFinder
   getter cache_path : String
 
-  def initialize(driver_directory)
-    @cache_path = File.join(driver_directory, "geckodriver.version")
+  def initialize(driver_directory, cache_file = "geckodriver.version")
+    @cache_path = File.join(driver_directory, cache_file)
   end
 
   def find : SemanticVersion?


### PR DESCRIPTION
Fixes #16

This PR does a few things
* Allow configuring the name of the cache file so your tests can have a different file from your development
* Give `Webdrivers::Cache` a `delete` method to delete the cache
* Clear out the test cache after the specs run