### PR TITLE
Release v0.4.3

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: webdrivers
-version: 0.4.2
+version: 0.4.3
 description: |
   Helps manage drivers for Selenium, such as the Chromedriver.
 authors:

--- a/src/webdrivers.cr
+++ b/src/webdrivers.cr
@@ -9,7 +9,7 @@ require "semantic_version"
 require "./webdrivers/**"
 
 module Webdrivers
-  VERSION                  = "0.4.2"
+  VERSION                  = "0.4.3"
   DEFAULT_DRIVER_DIRECTORY = "~/.webdrivers"
 
   Habitat.create do


### PR DESCRIPTION
This release fixes an issue when you're using Chrome v115 or later, and the chromedriver wouldn't install.