### PR TITLE
Add support for MacOS ARM build of geckodriver  

### DIFF
--- a/.github/workflows/crystal.yml
+++ b/.github/workflows/crystal.yml
@@ -31,9 +31,9 @@ jobs:
             crystal: latest
           - os: windows-latest
             crystal: latest
-          - os: macos-15-large # Intel platform
+          - os: macos-13 # Intel platform
             crystal: latest
-          - os: macos-latest-xlarge # ARM platform
+          - os: macos-latest # ARM platform
             crystal: latest
     runs-on: ${{matrix.os}}
     steps:

--- a/.github/workflows/crystal.yml
+++ b/.github/workflows/crystal.yml
@@ -2,9 +2,9 @@ name: Webdrivers CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   check-format:
@@ -25,16 +25,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Available images https://github.com/actions/runner-images?tab=readme-ov-file#available-images
         include:
           - os: ubuntu-latest
             crystal: latest
           - os: windows-latest
             crystal: latest
-          - os: macos-latest
+          - os: macos-15-large # Intel platform
+            crystal: latest
+          - os: macos-latest-xlarge # ARM platform
             crystal: latest
     runs-on: ${{matrix.os}}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: browser-actions/setup-chrome@v1
         with:
           chrome-version: stable

--- a/src/webdrivers/common.cr
+++ b/src/webdrivers/common.cr
@@ -13,6 +13,11 @@ module Webdrivers::Common
     {% end %}
   end
 
+  @[AlwaysInline]
+  def self.aarch64?
+    {{ flag?(:aarch64) }}
+  end
+
   def self.driver_directory
     File.expand_path(Webdrivers.settings.driver_directory, home: Path.home)
   end

--- a/src/webdrivers/gecko/install_driver_executor.cr
+++ b/src/webdrivers/gecko/install_driver_executor.cr
@@ -55,7 +55,8 @@ class Webdrivers::Gecko::InstallDriverExecutor
     when Common::OS::Linux
       "geckodriver-#{version_tag}-linux64.tar.gz"
     when Common::OS::Mac
-      "geckodriver-#{version_tag}-macos.tar.gz"
+      arch = Common.aarch64? ? "macos-aarch64" : "macos"
+      "geckodriver-#{version_tag}-#{arch}.tar.gz"
     when Common::OS::Windows
       "geckodriver-#{version_tag}-win64.zip"
     else


### PR DESCRIPTION
Currently the installation script always downloads the X86 build of gecko.
The release page also has prebuilt for ARM platform.

https://github.com/mozilla/geckodriver/releases/tag/v0.36.0