### PR TITLE
Lock Ameba to v1.5.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -17,4 +17,4 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 1.5
+    version: ~> 1.5.0


### PR DESCRIPTION
In Ameba v1.6 there are some reports that are false positives with Habitat.

Ref: https://github.com/crystal-ameba/ameba/issues/447