### PR TITLE
Adding Flatpak and Snap options for Linux as well as some ENV overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,7 @@ Flatpak exports) for a Chrome/Chromium binary in order to detect the installed
 version. Two environment variables let you override that search when your
 install lives somewhere unusual:
 
-- `WEBDRIVERS_CHROME_BINARY` — absolute path to the Chrome binary. When set,
-  the search is skipped and this path is used directly.
-- `WEBDRIVERS_CHROME_BINARY_NAME` — a binary name to look for in the standard
-  directories, in addition to the built-in names (`google-chrome`, `chrome`,
-  `chromium`, `chromium-browser`, `com.google.Chrome`). Useful if your
-  distribution ships Chrome under a different name.
+- `WEBDRIVERS_CHROME_BINARY` — absolute path to the Chrome binary. When set, the search is skipped and this path is used directly.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It automatically installs and updates supported webdrivers.
    ```yaml
    dependencies:
      webdrivers:
-       github: matthewmcgarvey/webdrivers.cr
+       github: crystal-loot/webdrivers.cr
    ```
 
 2. Run `shards install`
@@ -38,13 +38,33 @@ webdriver_path = Webdrivers::Chromedriver.install
 webdriver_path = Webdrivers::Geckodriver.install
 ```
 
+### Locating the Chrome browser
+
+On Linux, Webdrivers searches a list of common install paths (including Snap and
+Flatpak exports) for a Chrome/Chromium binary in order to detect the installed
+version. Two environment variables let you override that search when your
+install lives somewhere unusual:
+
+- `WEBDRIVERS_CHROME_BINARY` — absolute path to the Chrome binary. When set,
+  the search is skipped and this path is used directly.
+- `WEBDRIVERS_CHROME_BINARY_NAME` — a binary name to look for in the standard
+  directories, in addition to the built-in names (`google-chrome`, `chrome`,
+  `chromium`, `chromium-browser`, `com.google.Chrome`). Useful if your
+  distribution ships Chrome under a different name.
+
 ## Development
 
-TODO: Write development instructions here
+- Fork
+- Code
+- `crystal tool format spec/ src/`
+- `./bin/ameba`
+- `crystal spec`
+- Commit
+- Open PR
 
 ## Contributing
 
-1. Fork it (<https://github.com/matthewmcgarvey/webdrivers.cr/fork>)
+1. Fork it (<https://github.com/crystal-loot/webdrivers.cr/fork>)
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)

--- a/src/webdrivers/chrome/browser_version_finder.cr
+++ b/src/webdrivers/chrome/browser_version_finder.cr
@@ -17,6 +17,10 @@ class Webdrivers::Chrome::BrowserVersionFinder
   end
 
   private def windows_location : String?
+    if path = ENV["WEBDRIVERS_CHROME_BINARY"]?.presence
+      return path
+    end
+
     envs = ["LOCALAPPDATA", "PROGRAMFILES", "PROGRAMFILES(X86)"]
     directories = [
       Path.new("Google", "Chrome", "Applications"),
@@ -35,8 +39,27 @@ class Webdrivers::Chrome::BrowserVersionFinder
   end
 
   private def linux_location : String?
-    directories = ["/usr/local/sbin", "/usr/local/bin", "/usr/sbin", "/usr/bin", "/sbin", "/bin", "/snap/bin", "/opt/google/chrome"]
-    files = ["google-chrome", "chrome", "chromium", "chromium-browser"]
+    if path = ENV["WEBDRIVERS_CHROME_BINARY"]?.presence
+      return path
+    end
+
+    directories = [
+      "/usr/local/sbin",
+      "/usr/local/bin",
+      "/usr/sbin",
+      "/usr/bin",
+      "/sbin",
+      "/bin",
+      "/snap/bin",
+      "/opt/google/chrome",
+      "/var/lib/flatpak/exports/bin",
+      File.expand_path("~/.local/share/flatpak/exports/bin", home: Path.home),
+    ]
+    files = ["google-chrome", "chrome", "chromium", "chromium-browser", "com.google.Chrome"]
+
+    if name = ENV["WEBDRIVERS_CHROME_BINARY_NAME"]?.presence
+      files.unshift(name)
+    end
 
     directories.each do |dir|
       files.each do |file|
@@ -49,6 +72,10 @@ class Webdrivers::Chrome::BrowserVersionFinder
   end
 
   private def mac_location : String?
+    if path = ENV["WEBDRIVERS_CHROME_BINARY"]?.presence
+      return path
+    end
+
     directories = ["", File.expand_path("~", home: Path.home)]
     files = [
       "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",

--- a/src/webdrivers/chrome/browser_version_finder.cr
+++ b/src/webdrivers/chrome/browser_version_finder.cr
@@ -57,10 +57,6 @@ class Webdrivers::Chrome::BrowserVersionFinder
     ]
     files = ["google-chrome", "chrome", "chromium", "chromium-browser", "com.google.Chrome"]
 
-    if name = ENV["WEBDRIVERS_CHROME_BINARY_NAME"]?.presence
-      files.unshift(name)
-    end
-
     directories.each do |dir|
       files.each do |file|
         option = File.join(dir, file)


### PR DESCRIPTION
Fixes #22

If your code can't find chrome, you can just use `WEBDRIVERS_CHROME_BINARY` and point that to where your chrome is located. 